### PR TITLE
Ability to specify Ajv source code and to get modified data after validation

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -12,7 +12,7 @@ copyright_holder = Peter Sergeant
 [Prereqs]
 perl = 5.18.0
 Capture::Tiny = 0.48
-Cpanel::JSON::XS = 0
+Cpanel::JSON::XS = 3.0103
 JavaScript::Duktape::XS = 0.000075
 Path::Tiny = 0.104
 Test::More = 0

--- a/lib/Data/JSONSchema/Ajv.pm
+++ b/lib/Data/JSONSchema/Ajv.pm
@@ -80,16 +80,30 @@ Light-weight in this context just means it's not very many lines of actual Perl
 
   my $ajv = Data::JSONSchema::Ajv->new(
       { v5 => $JSON::PP::true }, # Ajv options. Try: {},
-      {}, # Module options. See `draft`
+      {}, # Module options. See below
   );
 
 Instantiates a new L<JavaScript::Duktape::XS> environment and loads C<Ajv> into it.
 Accepts two hashrefs (or undefs). The first is passed straight through to
 C<Ajv>, whose options are documented L<here|https://epoberezkin.github.io/ajv/>.
 
-The second one allows you to specify a JSON Schema draft version. Allowable
-options are C<04>, C<06>, and C<07>. No support for multiple schemas at this
-time. Default is C<07>.
+The second one allows you to specify options of this module:
+
+=over
+
+=item ajv_src
+
+String that contains source code of standalone version of Ajv library, which can be
+found L<here|https://cdnjs.com/libraries/ajv>. This module already has some version
+(possibly not last) of Ajv hardcoded inside it and will use it if this option doesn't
+specified.
+
+=item draft
+
+A JSON Schema draft version as a string. Allowable values are C<04>, C<06>, and C<07>.
+No support for multiple schemas at this time. Default is C<07>.
+
+=back
 
 =head2 make_validator
 
@@ -166,6 +180,7 @@ package Data::JSONSchema::Ajv {
 
         $my_options ||= {};
         my $draft_version = delete $my_options->{'draft'} // '07';
+        my $ajv_src = delete $my_options->{ajv_src};
         my $json_obj = delete $my_options->{'json'}
             // Cpanel::JSON::XS->new->ascii->allow_nonref;
         if ( keys %$my_options ) {
@@ -173,7 +188,7 @@ package Data::JSONSchema::Ajv {
         }
 
         my $js = JavaScript::Duktape::XS->new();
-        $js->eval($Data::JSONSchema::Ajv::src::src);
+        $js->eval($ajv_src || $Data::JSONSchema::Ajv::src::src);
 
         # Setup appropriately for different version of the schema
         if ( $draft_version eq '04' ) {

--- a/t/010_acceptance.t
+++ b/t/010_acceptance.t
@@ -17,7 +17,7 @@ die "Missing JSON test suite at $path" unless $path->exists;
 # Dive through the multi-hierarchy tests!
 for my $version (qw/4 6 7/) {
 
-    my $ajv = Data::JSONSchema::Ajv->new({},{ draft => "0$version", ajv_src => rand > 0.5 ? $Data::JSONSchema::Ajv::src::src : undef });
+    my $ajv = Data::JSONSchema::Ajv->new({},{ draft => "0$version" });
 
     subtest "Draft $version", sub {
         my $version_directory = $path->child("draft$version");

--- a/t/010_acceptance.t
+++ b/t/010_acceptance.t
@@ -17,7 +17,7 @@ die "Missing JSON test suite at $path" unless $path->exists;
 # Dive through the multi-hierarchy tests!
 for my $version (qw/4 6 7/) {
 
-    my $ajv = Data::JSONSchema::Ajv->new({},{ draft => "0$version" });
+    my $ajv = Data::JSONSchema::Ajv->new({},{ draft => "0$version", ajv_src => rand > 0.5 ? $Data::JSONSchema::Ajv::src::src : undef });
 
     subtest "Draft $version", sub {
         my $version_directory = $path->child("draft$version");

--- a/t/020_methods.t
+++ b/t/020_methods.t
@@ -1,0 +1,90 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use JSON::PP;
+
+use_ok 'Data::JSONSchema::Ajv';
+
+subtest new => sub {
+    my $ajv = eval { Data::JSONSchema::Ajv->new() };
+    ok $ajv, 'object successfully created when no parameters passed';
+    
+    $ajv = eval { Data::JSONSchema::Ajv->new( {}, { draft => '07', beep => 12 } ) };
+    ok !$ajv, 'object not created when unknown module parameter passed';
+    
+    $ajv = eval { Data::JSONSchema::Ajv->new( {}, { draft => 7 } ) };
+    ok !$ajv, 'object not created when unknown draft value passed';
+    
+    for my $draft (qw( 04 06 07 )) {
+        $ajv = eval { Data::JSONSchema::Ajv->new( {}, { draft => $draft } ) };
+        ok $ajv, "object successfully created for draft $draft";
+    }
+    
+    open my $fh, ">&STDERR";
+    close STDERR; # this test produces some garbage to stderr;
+    $ajv = eval { Data::JSONSchema::Ajv->new( {}, { ajv_src => 'perl + js = love' } ) };
+    open STDERR, ">&" . fileno($fh);
+    ok !$ajv, 'object not created when invalid source code of ajv passed';
+    
+    $ajv = eval { Data::JSONSchema::Ajv->new( {}, { ajv_src => 'function Ajv() {}' } ) };
+    ok $ajv, 'object successfully created for valid ajv_src';
+};
+
+subtest make_validator => sub {
+    my $ajv = Data::JSONSchema::Ajv->new();
+    
+    open my $fh, ">&STDERR";
+    close STDERR; # this test produces some garbage to stderr;
+    my $validator = eval { $ajv->make_validator("my first schema") };
+    open STDERR, ">&" . fileno($fh);
+    ok !$validator, "can't create validator for invalid schema";
+    
+    $validator = eval { $ajv->make_validator({ type => 'integer', minimum => 1, maximum => 1000 }) };
+    ok $validator, 'validator successfully created for valid schema';
+    
+    $validator = eval { $ajv->make_validator('{ "type": "integer", "minimum": 1, "maximum": 1000 }') };
+    ok $validator, 'validator successfully created for valid schema passed as JSON';
+    
+    isa_ok $validator, 'Data::JSONSchema::Ajv::Validator';
+};
+
+subtest validate => sub {
+    my $ajv = Data::JSONSchema::Ajv->new();
+    my $validator = $ajv->make_validator({ type => 'integer', minimum => 1, maximum => 1000 });
+    
+    my $errors = $validator->validate("smth");
+    ok $errors, "can't validate invalid data";
+    
+    $errors = $validator->validate(99);
+    ok !$errors, 'valid data validated successfully';
+    
+    $errors = $validator->validate(\99);
+    ok !$errors, 'can validate scalars passed by reference';
+    
+    $ajv = Data::JSONSchema::Ajv->new({ coerceTypes => $JSON::PP::true });
+    $validator = $ajv->make_validator({ type => 'object', properties => {
+        rectype  => {type => 'string'},
+        prio     => {type => 'integer'},
+        can_edit => {type => 'boolean'} } 
+    });
+    
+    my $data = { rectype => 'A', prio => '1', can_edit => 'true' };
+    my $copy = { %$data };
+    
+    $errors = $validator->validate($data);
+    ok !$errors, "can validate non valid types when `coerceTypes' option specified";
+    is_deeply $data, $copy, 'original data not modified';
+    
+    $errors = $validator->validate(\$data);
+    ok !$errors, "can validate non valid types when `coerceTypes' option specified and data passed by reference";
+    $copy->{prio} = 1;
+    $copy->{can_edit} = $JSON::PP::true;
+    is_deeply $data, $copy, 'original data modified to pass schema';
+    is encode_json( [@$data{qw(rectype prio can_edit)}] ),
+       encode_json( ['A', 1, $JSON::PP::true] ), 'all types are correct when modified data converted to JSON';
+};
+
+done_testing();


### PR DESCRIPTION
Currently Ajv hardcoded inside module. I think it will be good to have ability to specify source code manually. For example we want to use newer version of Ajv or locally patched version (my case). I added `ajv_src` option in this PR.

Ajv may modify data during validation (See "Modifying data during validation" at https://ajv.js.org/). We want to get such modifed data to be able to send it then to some service, which validates it strictly, so it will not pass without this modifications. I added ability to get such modifications if data will be passed by reference: `$data = {a => 1, b => 2}; $validator->validate(\$data)`.

I also added some checks for JS errors and tests.

